### PR TITLE
change tab icon from *i*nfo to key (category-auth)

### DIFF
--- a/js/checksum.tabview.js
+++ b/js/checksum.tabview.js
@@ -19,7 +19,7 @@
      */
     getIcon: function() {
 
-      return 'icon-info';
+      return 'icon-category-auth';
 
     },
 


### PR DESCRIPTION
the tab icon was the same as the [metadata app](https://apps.nextcloud.com/apps/metadata), so i changed it to the key category icon, which is in my opinion a bit more suitable as well.