### PR TITLE
Fix invalid label of sha512

### DIFF
--- a/src/views/ChecksumTab.vue
+++ b/src/views/ChecksumTab.vue
@@ -48,7 +48,7 @@ const algorithms = [
 	{ id: 'sha1', label: 'SHA1' },
 	{ id: 'sha256', label: 'SHA256' },
 	{ id: 'sha384', label: 'SHA384' },
-	{ id: 'sha512', label: 'SHA1' },
+	{ id: 'sha512', label: 'SHA512' },
 	{ id: 'crc32', label: 'CRC32' },
 	{ id: 'crc32b', label: 'CRC32b' },
 ]

--- a/src/views/ChecksumTab20.vue
+++ b/src/views/ChecksumTab20.vue
@@ -51,7 +51,7 @@ const algorithms = [
 	{ id: 'sha1', label: 'SHA1' },
 	{ id: 'sha256', label: 'SHA256' },
 	{ id: 'sha384', label: 'SHA384' },
-	{ id: 'sha512', label: 'SHA1' },
+	{ id: 'sha512', label: 'SHA512' },
 	{ id: 'crc32', label: 'CRC32' },
 	{ id: 'crc32b', label: 'CRC32b' },
 ]


### PR DESCRIPTION
The SHA512 algorithm currently has a wrong label on the vue frontend.