### PR TITLE
Remove Nextcloud upper version constraints

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -28,7 +28,7 @@
     <bugs>https://github.com/westberliner/checksum/issues</bugs>
     <screenshot>https://raw.githubusercontent.com/westberliner/checksum/master/screenshots/checksum.gif</screenshot>
     <dependencies>
-        <php min-version="7.4" />
-        <nextcloud min-version="21" max-version="31" />
+        <php min-version="7.4"/>
+        <nextcloud min-version="21"/>
     </dependencies>
 </info>


### PR DESCRIPTION
Remove Nextcloud upper version constraints. Nextcloud releases come out every 3 months. Currently, no known compatibility issue requires forbidding the usage with the latest (and future) releases.
- Later on, if a serious change is required, then we can temporarily forbid the deployment with a new release that contains the constraints by re-introducing the upper limitation until the solution is provided.

This PR should resolve nextcloud/server#107 and similar issues going forward.

@westberliner, What is your opinion?