### PR TITLE
fix(#108): include l10n/*.json translation files in release archive

### DIFF
--- a/.exclude
+++ b/.exclude
@@ -3,7 +3,10 @@
 ./stylelint.config.js
 ./vite.config.js
 ./vitest.config.ts
-./*.json
+package.json
+package-lock.json
+composer.json
+tsconfig.json
 *.log
 *.lock
 ./node_modules

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**[Unreleased]**
+
+- fix(#108): include l10n/*.json translation files in release archive
+
 **2.1.1**
 
 - fix deployment


### PR DESCRIPTION
The .exclude file used '*'./*.json'*' to skip root-level config JSON files (package.json, composer.json, etc.), but GNU tar's -X strips the leading './' and treats the remainder as a basename pattern. As a result, every file matching '*.json' was excluded — including all of l10n/*.json, which left the installed app untranslated.

Replace the wildcard with the explicit list of root JSON files so that translation JSON files in l10n/ are no longer accidentally excluded from the release tarball.